### PR TITLE
link new uploads to metacpan

### DIFF
--- a/lib/CPANBot.pm
+++ b/lib/CPANBot.pm
@@ -191,7 +191,7 @@ sub _handle_article {
 			event => '_handle_dbi',
 			placeholders => [ $self->{botnick}, 'upload' ],
 			_module => $module,
-			_response => "ACTION CPAN Upload: $module by $author",
+			_response => "ACTION CPAN Upload: $module by $author (http://metacpan.org/release/$author/$module)",
 			_xref => $xref,
 		  },
 		);


### PR DESCRIPTION
MetaCPAN is quite fast with indexing new uploads. Most of the time the upload has been indexed before GumbyNET sends its message so the link should work most of the time.
